### PR TITLE
feature(ruszzer): introduce cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 rand = "0.8.3"
+clap = { version = "3.0.0-beta.2", features = ["yaml"] }

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -1,0 +1,32 @@
+name: ruszzer
+version: "0.1.0"
+author: "BrMtssk <br.mtssk@gmail.com>"
+about: A Fuzzer implementation in Rust
+args:
+  - INPUT:
+      help: Path to binary input file (relative to top level)
+      required: true
+      takes_value: true
+      index: 1
+  - strategy:
+      help: Fuzzing strategy
+      required: true
+      takes_value: true
+      index: 2
+      possible_values: [ random, mutation ]
+  - debug:
+      help: Debug mode
+      short: d
+  - verbose:
+      help: Level of verbosity
+      short: v
+
+subcommands:
+  - test:
+      about: controls testing features (WIP)
+      version: "0.1.0"
+      author: BrMtssk <br.mtssk@gmail.com>
+      args:
+        - debug:
+            short: d
+            about: print debug information

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod fuzzer;
 mod runner;
 mod strategy;
 
+use clap::{App, load_yaml};
 use fuzzer::fuzzer_impl::FuzzerImpl;
 use fuzzer::api::Fuzzer;
 use runner::gcov_binary_runner::GCovBinaryRunner;
@@ -9,13 +10,24 @@ use strategy::mutation_strategy::MutationStrategy;
 use strategy::random_strategy::RandomStrategy;
 
 fn main() {
-    // Prepare option when have a CLI.
-    let strategy_option = "random";
+    let yaml = load_yaml!("cli.yaml");
+    let matches = App::from(yaml).get_matches();
+
+    let strategy_option = matches.value_of("strategy").unwrap();
+    let input_path = matches.value_of("INPUT").unwrap();
+
+    let split = input_path.split("/");
+    let path_vector = split.collect::<Vec<&str>>();
+    let binary_path = path_vector[0];
+    let binary_name = path_vector[1];
+
 
     let runner = GCovBinaryRunner {
-        binary_path: String::from("fuzzy_targets"),
-        binary_name: String::from("cgi_decode"),
+        binary_path: String::from(binary_path),
+        binary_name: String::from(binary_name),
     };
+
+    println!("Running {} fuzzer", strategy_option);
 
     // RANDOM_FUZZER
     let trials = 1000;


### PR DESCRIPTION
simple implementation of a CLI using clap. It has:
INPUT path (required); strategy (required - random or mutation currently), flags: debug (-d), verbose (-v).
The flags are not yet changing internal behaviour of the program, but they are available in `main`'s context.